### PR TITLE
doc: add a simple note for installing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ TODO: Options Documentation
 ## How to develop
 
 ```
+# If you are not on MacOS try running `yarn --ignore-platform` instead of `yarn install`.
 yarn install
 yarn build
 yarn test


### PR DESCRIPTION
If you are not on MacOS, `yarn install` will exclude optional dependency`fsevents` that is not platform compatible. Although a normal behavior, this makes `yarn start` to fail. 
I added a simple note to bypass platform checking when `yarn install`ing packages.